### PR TITLE
add GitHub Actions CI for build and unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install compiler and tools
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y g++-15 autoconf automake pandoc
+
+      - name: Build
+        run: |
+          ./autogen.sh
+          ./configure CXX=g++-15
+          make
+
+      - name: Unit tests
+        run: make -C tests check TESTS="fs_acl_test options_test"


### PR DESCRIPTION
Adds a minimal GitHub Actions workflow that:

- Compiles the project with GCC 15 on Ubuntu 24.04
- Runs the two C++ unit tests (`fs_acl_test`, `options_test`)

The shell integration tests are excluded since they require setuid root and a 6.13+ kernel, which aren't available on GitHub Actions runners. This at least catches compilation regressions on every push and PR.

Single file added: `.github/workflows/build.yml`